### PR TITLE
update dependency for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "tape": "4.5.1"
   },
   "dependencies": {
-    "shell-escape-tag": "1.0.0"
+    "shell-escape-tag": "^1.2.1"
   }
 }


### PR DESCRIPTION
The dependent module, `shell-escape-tag` was dependent on an old version of `lodash` which had a prototype pollution security issue. The more recent versions of the `shell-escape-tag` depend on a patched version of `lodash`, so the `shell-tag` module should also be updated to the latest.